### PR TITLE
Added bootstro.on_complete(), bootstro.on_exit() and bootstro.on_step()

### DIFF
--- a/bootstro.js
+++ b/bootstro.js
@@ -29,6 +29,9 @@ $(document).ready(function(){
             stopOnEsc : true
         };
         var settings;
+        var onCompleteFunc;
+        var onExitFunc;
+        var onStepFunc;
         
         
         //===================PRIVATE METHODS======================
@@ -141,6 +144,10 @@ $(document).ready(function(){
         //destroy active popover and remove backdrop
         bootstro.stop = function()
         {
+            //call onExit callback function if needed
+            if (this.onExitFunc != undefined) {
+                this.onExitFunc.call(this);
+            }
             bootstro.destroy_popover(activeIndex);
             bootstro.unbind();
             $("div.bootstro-backdrop").remove();
@@ -150,6 +157,10 @@ $(document).ready(function(){
         //go to the popover number idx starting from 0
         bootstro.go_to = function(idx) 
         {
+            //call onStep callback function if needed
+            if (this.onStepFunc != undefined) {
+                this.onStepFunc.call(this);
+            }
             //destroy current popover if any
             bootstro.destroy_popover(activeIndex);
             if (count != 0)
@@ -173,7 +184,10 @@ $(document).ready(function(){
         {
             if (activeIndex + 1 == count)
             {
-                alert('End of introduction');
+                //call onComplete callback function if needed
+                if (this.onCompleteFunc != undefined) {
+                    this.onCompleteFunc.call(this);
+                }
             }
             else 
                 bootstro.go_to(activeIndex + 1);
@@ -251,7 +265,28 @@ $(document).ready(function(){
         {
             $("html").unbind('click.bootstro');
             $(document).unbind('keydown.bootstro');
-        }
+        };
            
+        bootstro.on_complete = function(callbackFunction)
+        {
+            if (Object.prototype.toString.call(callbackFunction) == '[object Function]') {
+                this.onCompleteFunc = callbackFunction;
+            }
+        };
+
+        bootstro.on_exit = function(callbackFunction)
+        {
+            if (Object.prototype.toString.call(callbackFunction) == '[object Function]') {
+                this.onExitFunc = callbackFunction;
+            }
+        };
+
+        bootstro.on_step = function(callbackFunction)
+        {
+            if (Object.prototype.toString.call(callbackFunction) == '[object Function]') {
+                this.onStepFunc = callbackFunction;
+            }
+        };
+
      }( window.bootstro = window.bootstro || {}, jQuery ));
 });


### PR DESCRIPTION
Added three new public methods that allow hooking functions to three bootstro events:
- Slide show complete
- Slide show stopped
- Slide changed (next or prev)

Now you can do this:

``` javascript
    $(document).ready(function(){
        $("#demo").click(function(){
            bootstro.start();
        });

        bootstro.on_complete(
          function() {
            // last slide reached
            // close slide show automatically. no more annoying alert.
            bootstro.stop();
          }
        );

        bootstro.on_step(
          function() {
            // Slide changed.
            // Notify Google Analytics!
          }
        );

        bootstro.on_exit(
          function() {
            // slide show stopped.
            // focus() on registration button!
          }
        );
    });

```
